### PR TITLE
Added validated field to area and point CRUD functions

### DIFF
--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -8,6 +8,5 @@ export class AreaDto {
   coordinates: number[][][];
   medias: MediaRelationDto[];
   validated: boolean;
-  color: string;
   member: string;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -8,5 +8,6 @@ export class AreaDto {
   coordinates: number[][][];
   medias: MediaRelationDto[];
   validated: boolean;
+  color: string;
   member: string;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -7,4 +7,5 @@ export class AreaDto {
   type = 'Polygon';
   coordinates: number[][][];
   medias: MediaRelationDto[];
+  validated: boolean;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -8,4 +8,5 @@ export class AreaDto {
   coordinates: number[][][];
   medias: MediaRelationDto[];
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -5,7 +5,6 @@ export class CreateAreaDto {
   title: string;
   description?: string;
   validated: boolean;
-  color: string;
   member: string;
   
   @IsArray()

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -5,7 +5,7 @@ export class CreateAreaDto {
   title: string;
   description?: string;
   validated: boolean;
-  color: 'yellow',
+  color: string;
   member: string;
   
   @IsArray()

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -5,6 +5,7 @@ export class CreateAreaDto {
   title: string;
   description?: string;
   validated: boolean;
+  member: string;
   
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -4,7 +4,8 @@ import { ArrayMinSize, IsArray, ValidateNested } from 'class-validator';
 export class CreateAreaDto {
   title: string;
   description?: string;
-
+  validated: boolean;
+  
   @IsArray()
   @ValidateNested({ each: true })
   @ArrayMinSize(3, {

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -5,6 +5,7 @@ export class CreateAreaDto {
   title: string;
   description?: string;
   validated: boolean;
+  color: 'yellow',
   member: string;
   
   @IsArray()

--- a/src/mapas/dto/createPoint.dto.ts
+++ b/src/mapas/dto/createPoint.dto.ts
@@ -4,4 +4,5 @@ export class CreatePointDto {
   latitude: number;
   longitude: number;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/createPoint.dto.ts
+++ b/src/mapas/dto/createPoint.dto.ts
@@ -3,4 +3,5 @@ export class CreatePointDto {
   description?: string;
   latitude: number;
   longitude: number;
+  validated: boolean;
 }

--- a/src/mapas/dto/createPoint.dto.ts
+++ b/src/mapas/dto/createPoint.dto.ts
@@ -4,5 +4,6 @@ export class CreatePointDto {
   latitude: number;
   longitude: number;
   validated: boolean;
+  color: string;
   member: string;
 }

--- a/src/mapas/dto/createPoint.dto.ts
+++ b/src/mapas/dto/createPoint.dto.ts
@@ -4,6 +4,5 @@ export class CreatePointDto {
   latitude: number;
   longitude: number;
   validated: boolean;
-  color: string;
   member: string;
 }

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -8,6 +8,5 @@ export class PointDto {
   coordinates: number[];
   medias: MediaRelationDto[];
   validated: boolean;
-  color: string;
   member: string;
 }

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -8,4 +8,5 @@ export class PointDto {
   coordinates: number[];
   medias: MediaRelationDto[];
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -8,5 +8,6 @@ export class PointDto {
   coordinates: number[];
   medias: MediaRelationDto[];
   validated: boolean;
+  color: string;
   member: string;
 }

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -7,4 +7,5 @@ export class PointDto {
   type = 'Point';
   coordinates: number[];
   medias: MediaRelationDto[];
+  validated: boolean;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -2,4 +2,5 @@ export class UpdateAreaDto {
   id: string;
   title?: string;
   description?: string;
+  validated: boolean;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -3,4 +3,5 @@ export class UpdateAreaDto {
   title?: string;
   description?: string;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -3,6 +3,5 @@ export class UpdateAreaDto {
   title?: string;
   description?: string;
   validated: boolean;
-  color: string;
   member: string;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -3,5 +3,6 @@ export class UpdateAreaDto {
   title?: string;
   description?: string;
   validated: boolean;
+  color: string;
   member: string;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -2,4 +2,5 @@ export class UpdatePointDto {
   id: string;
   title?: string;
   description?: string;
+  validated: boolean;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -3,4 +3,5 @@ export class UpdatePointDto {
   title?: string;
   description?: string;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -3,6 +3,5 @@ export class UpdatePointDto {
   title?: string;
   description?: string;
   validated: boolean;
-  color: string;
   member: string;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -3,5 +3,6 @@ export class UpdatePointDto {
   title?: string;
   description?: string;
   validated: boolean;
+  color: string;
   member: string;
 }

--- a/test/mapas/mapas.controller.spec.ts
+++ b/test/mapas/mapas.controller.spec.ts
@@ -131,7 +131,6 @@ describe('MapasController', () => {
         latitude: 0,
         longitude: 0,
         validated: false,
-        color: 'yellow',
         member: 'memberId'
       }),
     ).toBe(id);
@@ -170,7 +169,6 @@ describe('MapasController', () => {
         title: 'setor leste',
         description: 'setor leste',
         validated: false,
-        color: 'yellow',
         member: 'memberId'
       }),
     ).toStrictEqual(id);
@@ -205,7 +203,6 @@ describe('MapasController', () => {
           { latitude: 2, longitude: 2 },
         ],
         validated: false,
-        color: 'yellow',
         member: 'memberId'
       }),
     ).toBe(id);
@@ -251,7 +248,6 @@ describe('MapasController', () => {
         title: 'teste',
         description: 'teste',
         validated: false,
-        color: 'yellow',
         member: 'memberId'
       }),
     ).toStrictEqual(id);

--- a/test/mapas/mapas.controller.spec.ts
+++ b/test/mapas/mapas.controller.spec.ts
@@ -130,6 +130,7 @@ describe('MapasController', () => {
         description: 'teste',
         latitude: 0,
         longitude: 0,
+        validated: false
       }),
     ).toBe(id);
   });
@@ -166,6 +167,7 @@ describe('MapasController', () => {
         id: id,
         title: 'setor leste',
         description: 'setor leste',
+        validated: false
       }),
     ).toStrictEqual(id);
   });
@@ -198,6 +200,7 @@ describe('MapasController', () => {
           { latitude: 1, longitude: 1 },
           { latitude: 2, longitude: 2 },
         ],
+        validated: false
       }),
     ).toBe(id);
   });
@@ -241,6 +244,7 @@ describe('MapasController', () => {
         id: id,
         title: 'teste',
         description: 'teste',
+        validated: false
       }),
     ).toStrictEqual(id);
   });

--- a/test/mapas/mapas.controller.spec.ts
+++ b/test/mapas/mapas.controller.spec.ts
@@ -130,7 +130,8 @@ describe('MapasController', () => {
         description: 'teste',
         latitude: 0,
         longitude: 0,
-        validated: false
+        validated: false,
+        member: 'memberId'
       }),
     ).toBe(id);
   });
@@ -167,7 +168,8 @@ describe('MapasController', () => {
         id: id,
         title: 'setor leste',
         description: 'setor leste',
-        validated: false
+        validated: false,
+        member: 'memberId'
       }),
     ).toStrictEqual(id);
   });
@@ -200,7 +202,8 @@ describe('MapasController', () => {
           { latitude: 1, longitude: 1 },
           { latitude: 2, longitude: 2 },
         ],
-        validated: false
+        validated: false,
+        member: 'memberId'
       }),
     ).toBe(id);
   });
@@ -244,7 +247,8 @@ describe('MapasController', () => {
         id: id,
         title: 'teste',
         description: 'teste',
-        validated: false
+        validated: false,
+        member: 'memberId'
       }),
     ).toStrictEqual(id);
   });

--- a/test/mapas/mapas.controller.spec.ts
+++ b/test/mapas/mapas.controller.spec.ts
@@ -131,6 +131,7 @@ describe('MapasController', () => {
         latitude: 0,
         longitude: 0,
         validated: false,
+        color: 'yellow',
         member: 'memberId'
       }),
     ).toBe(id);
@@ -169,6 +170,7 @@ describe('MapasController', () => {
         title: 'setor leste',
         description: 'setor leste',
         validated: false,
+        color: 'yellow',
         member: 'memberId'
       }),
     ).toStrictEqual(id);
@@ -203,6 +205,7 @@ describe('MapasController', () => {
           { latitude: 2, longitude: 2 },
         ],
         validated: false,
+        color: 'yellow',
         member: 'memberId'
       }),
     ).toBe(id);
@@ -248,6 +251,7 @@ describe('MapasController', () => {
         title: 'teste',
         description: 'teste',
         validated: false,
+        color: 'yellow',
         member: 'memberId'
       }),
     ).toStrictEqual(id);


### PR DESCRIPTION
Co-authored-by: Gian Medeiros <gianmedeiros14@gmail.com>

## Motivação
Para a criação, edição e visualização de pontos disponíveis no banco de dados, era necessário um campo que indicasse o estado de validação do ponto.

- Usuários comuns podem criar pontos, porém os pontos criados devem ser validados por um usuário **Administrador** para que fiquem disponíveis para todos os usuários.
- Pontos não validados devem aparecer na cor amarela, e apenas para o Líder da comunidade
- Essa validação deve ser feita no front-end com base no estado de validação do Ponto/Área retornado pelo back-end 

## Mudanças feitas
- Foi adicionado um campo **Validated** nos endpoints de CRUD dos pontos e áreas
- O campo Validated é booleano

## Tarefa relacionada
[#74](https://github.com/fga-eps-mds/2021-2-Cartografia-social-Doc/issues/74) e [#114](https://github.com/fga-eps-mds/2021-2-Cartografia-social-Doc/issues/114) 

